### PR TITLE
fix: read Azure ARM_* secrets in terratest and cleanup steps

### DIFF
--- a/.github/workflows/_tf_test.yml
+++ b/.github/workflows/_tf_test.yml
@@ -113,9 +113,9 @@ jobs:
         timeout-minutes: ${{ inputs.apply_timeout }}
         uses: ./.github/actions/terratest
         env:
-          ARM_CLIENT_ID:        ${{ secrets.AZURE_CLIENT_ID }}
-          ARM_SUBSCRIPTION_ID:  ${{ secrets.AZURE_SUBSCRIPTION_ID }}
-          ARM_TENANT_ID:        ${{ secrets.AZURE_TENANT_ID }}
+          ARM_CLIENT_ID:        ${{ secrets.ARM_CLIENT_ID }}
+          ARM_SUBSCRIPTION_ID:  ${{ secrets.ARM_SUBSCRIPTION_ID }}
+          ARM_TENANT_ID:        ${{ secrets.ARM_TENANT_ID }}
           # Zscaler OneAPI (Zidentity)
           ZSCALER_CLIENT_ID:     ${{ secrets.ZSCALER_CLIENT_ID }}
           ZSCALER_CLIENT_SECRET: ${{ secrets.ZSCALER_CLIENT_SECRET }}
@@ -191,9 +191,9 @@ jobs:
         with:
           pr-id: ${{ inputs.pr-id }}
         env:
-          ARM_CLIENT_ID: ${{ secrets.AZURE_CLIENT_ID }}
-          ARM_SUBSCRIPTION_ID: ${{ secrets.AZURE_SUBSCRIPTION_ID }}
-          ARM_TENANT_ID: ${{ secrets.AZURE_TENANT_ID }}
+          ARM_CLIENT_ID: ${{ secrets.ARM_CLIENT_ID }}
+          ARM_SUBSCRIPTION_ID: ${{ secrets.ARM_SUBSCRIPTION_ID }}
+          ARM_TENANT_ID: ${{ secrets.ARM_TENANT_ID }}
 
       - name: cleanup AWS
         if: inputs.cloud == 'aws'


### PR DESCRIPTION
## Summary
- Align the Azure terratest and subscription cleanup steps in `_tf_test.yml` to read the `ARM_CLIENT_ID` / `ARM_SUBSCRIPTION_ID` / `ARM_TENANT_ID` secret names that the consuming Azure module repositories already configure.
- Previously these steps read `secrets.AZURE_*`, which resolved to empty in repos that store the credentials under the `ARM_*` names, causing `azure/login` to fail with "Ensure 'client-id' and 'tenant-id' are supplied."

## Test plan
- [ ] Re-run the Azure module CI (`terraform-azurerm-zpa-app-connector-modules`) and confirm `azure/login` authenticates and the terratest + cleanup steps run.